### PR TITLE
feat: add CVE grouping option

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,10 @@
       </select>
     </div>
 
+    <div class="form-group">
+      <label><input type="checkbox" id="groupByCve"> Group by CVE</label>
+    </div>
+
     <div id="resultsCount" style="font-weight: bold;"></div>
 
 

--- a/index.html
+++ b/index.html
@@ -57,19 +57,21 @@
   </div>
 
   <div class="filter-row bottom-row">
-    <div class="form-group">
-      <label for="perPage">Results per page</label>
-      <select id="perPage">
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50" selected>50</option>
-        <option value="100">100</option>
-      </select>
-    </div>
-    <button id="expandAll" class="filter-button">Expand all</button>
-    <button id="collapseAll" class="filter-button">Collapse all</button>
     <div id="resultsCount" style="font-weight: bold;"></div>
-    <div id="pagination"></div>
+    <div class="right-controls">
+      <button id="expandAll" class="filter-button">Expand all</button>
+      <button id="collapseAll" class="filter-button">Collapse all</button>
+      <div class="form-group">
+        <label for="perPage">Results per page</label>
+        <select id="perPage">
+          <option value="10">10</option>
+          <option value="25">25</option>
+          <option value="50" selected>50</option>
+          <option value="100">100</option>
+        </select>
+      </div>
+      <div id="pagination"></div>
+    </div>
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -66,7 +66,8 @@
         <option value="100">100</option>
       </select>
     </div>
-    <button id="collapseAll">Collapse all</button>
+    <button id="expandAll" class="filter-button">Expand all</button>
+    <button id="collapseAll" class="filter-button">Collapse all</button>
     <div id="resultsCount" style="font-weight: bold;"></div>
     <div id="pagination"></div>
   </div>

--- a/index.html
+++ b/index.html
@@ -57,8 +57,18 @@
   </div>
 
   <div class="filter-row bottom-row">
+    <div class="form-group">
+      <label for="perPage">Results per page</label>
+      <select id="perPage">
+        <option value="10">10</option>
+        <option value="25">25</option>
+        <option value="50" selected>50</option>
+        <option value="100">100</option>
+      </select>
+    </div>
     <button id="collapseAll">Collapse all</button>
     <div id="resultsCount" style="font-weight: bold;"></div>
+    <div id="pagination"></div>
   </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -57,24 +57,8 @@
   </div>
 
   <div class="filter-row bottom-row">
-    <div class="form-group">
-      <label for="perPage">Results per page</label>
-      <select id="perPage">
-        <option value="10">10</option>
-        <option value="25">25</option>
-        <option value="50" selected>50</option>
-        <option value="100">100</option>
-      </select>
-    </div>
-
-    <div class="form-group">
-      <label><input type="checkbox" id="groupByCve"> Group by CVE</label>
-    </div>
-
+    <button id="collapseAll">Collapse all</button>
     <div id="resultsCount" style="font-weight: bold;"></div>
-
-
-    <div id="pagination"></div>
   </div>
 </div>
 

--- a/script.js
+++ b/script.js
@@ -1,8 +1,5 @@
 let cveData = [];
 let filteredData = [];
-let currentPage = 1;
-let resultsPerPage = 50;
-let groupByCve = false;
 
 document.getElementById("fileInput").addEventListener("change", (event) => {
   const file = event.target.files[0];
@@ -12,7 +9,6 @@ document.getElementById("fileInput").addEventListener("change", (event) => {
   reader.onload = (e) => {
     try {
       cveData = JSON.parse(e.target.result).matches;
-      currentPage = 1;
       applyFilters();
     } catch (err) {
       alert("ERROR parsing JSON file");
@@ -21,48 +17,24 @@ document.getElementById("fileInput").addEventListener("change", (event) => {
   reader.readAsText(file);
 });
 
-document.getElementById("perPage").addEventListener("change", () => {
-  currentPage = 1;
-  render();
-});
+document.getElementById("searchId").addEventListener("input", applyFilters);
 
-document.getElementById("groupByCve").addEventListener("change", (e) => {
-  groupByCve = e.target.checked;
-  render();
-});
-
-document.getElementById("searchId").addEventListener("input", () => {
-  currentPage = 1;
-  applyFilters();
-});
-
-document.getElementById("riskThreshold").addEventListener("input", () => {
-  currentPage = 1;
-  applyFilters();
-});
+document.getElementById("riskThreshold").addEventListener("input", applyFilters);
 
 document.querySelectorAll('input[name="severity"]').forEach(cb => {
-  cb.addEventListener("change", () => {
-    currentPage = 1;
-    applyFilters();
-  });
+  cb.addEventListener("change", applyFilters);
 });
 
 document.querySelectorAll('input[name="fixstate"]').forEach(cb => {
-  cb.addEventListener("change", () => {
-    currentPage = 1;
-    applyFilters();
-  });
+  cb.addEventListener("change", applyFilters);
 });
 
-document.getElementById("percentileThreshold").addEventListener("input", () => {
-  currentPage = 1;
-  applyFilters();
-});
+document.getElementById("percentileThreshold").addEventListener("input", applyFilters);
 
-document.getElementById("riskScore").addEventListener("input", () => {
-  currentPage = 1;
-  applyFilters();
+document.getElementById("riskScore").addEventListener("input", applyFilters);
+
+document.getElementById("collapseAll").addEventListener("click", () => {
+  document.querySelectorAll("#cve-list details").forEach(d => d.open = false);
 });
 
 
@@ -93,116 +65,50 @@ function applyFilters() {
 
 
 function render() {
-  resultsPerPage = parseInt(document.getElementById("perPage").value);
-
   const uniqueCves = new Set(filteredData.map(f => f.vulnerability.id));
   const uniqueArtifacts = new Set(filteredData.map(f => f.artifact?.id));
 
   if (filteredData.length === 0) {
     document.getElementById("cve-list").innerHTML = "<div class=\"no-results\">No results found.</div>";
     document.getElementById("resultsCount").textContent = "No results";
-    const pagination = document.getElementById("pagination");
-    pagination.innerHTML = "";
-    pagination.style.display = "none";
     return;
   }
 
-  if (groupByCve) {
-    // Using <details> for an accessible, keyboard-friendly disclosure of groups
-    const grouped = filteredData.reduce((acc, item) => {
-      const id = item.vulnerability.id;
-      (acc[id] = acc[id] || []).push(item);
-      return acc;
-    }, {});
+  // Using <details> for an accessible, keyboard-friendly disclosure of groups
+  const grouped = filteredData.reduce((acc, item) => {
+    const id = item.vulnerability.id;
+    (acc[id] = acc[id] || []).push(item);
+    return acc;
+  }, {});
 
-    const list = Object.entries(grouped).map(([cveId, items]) => {
-      const entries = items.map(item => {
-        const epss = item.vulnerability.epss?.[0]?.epss ?? "n/a";
-        const artifactName = item.artifact?.id ?? "Unknown";
-        const percentile = item.vulnerability.epss?.[0]?.percentile ?? "n/a";
-        const percentileFormatted = typeof percentile === 'number' ? (percentile * 100).toFixed(2) + '%' : "n/a";
-        const risk = item.vulnerability.risk ?? "n/a";
-        const riskFormatted = typeof risk === 'number' ? risk.toFixed(2) : "n/a";
-        const fixState = item.vulnerability.fix?.state ?? "unknown";
-        return `
-          <div class="cve-entry">
-            <strong><a style="color: #005f73" href="https://nvd.nist.gov/vuln/detail/${item.vulnerability.id}" target="_blank">
-              ${item.vulnerability.id}
-            </a></strong>
-            <div>Artifact: ${artifactName}</div>
-            <div>Severity: ${item.vulnerability.severity}</div>
-            <div>Namespace: ${item.vulnerability.namespace}</div>
-            <div>EPSS: ${epss}</div>
-            <div>Percentile: ${percentileFormatted}</div>
-            <div>Risk Score: ${riskFormatted}</div>
-            <div>Fix Status: <strong>${fixState}</strong></div>
-          </div>
-        `;
-      }).join("");
-      return `<details><summary>${cveId} (${items.length})</summary>${entries}</details>`;
+  const list = Object.entries(grouped).map(([cveId, items]) => {
+    const entries = items.map(item => {
+      const epss = item.vulnerability.epss?.[0]?.epss ?? "n/a";
+      const artifactName = item.artifact?.id ?? "Unknown";
+      const percentile = item.vulnerability.epss?.[0]?.percentile ?? "n/a";
+      const percentileFormatted = typeof percentile === 'number' ? (percentile * 100).toFixed(2) + '%' : "n/a";
+      const risk = item.vulnerability.risk ?? "n/a";
+      const riskFormatted = typeof risk === 'number' ? risk.toFixed(2) : "n/a";
+      const fixState = item.vulnerability.fix?.state ?? "unknown";
+      return `
+        <div class=\"cve-entry\">
+          <div>Artifact: ${artifactName}</div>
+          <div>Severity: ${item.vulnerability.severity}</div>
+          <div>Namespace: ${item.vulnerability.namespace}</div>
+          <div>EPSS: ${epss}</div>
+          <div>Percentile: ${percentileFormatted}</div>
+          <div>Risk Score: ${riskFormatted}</div>
+          <div>Fix Status: <strong>${fixState}</strong></div>
+        </div>
+      `;
     }).join("");
-
-    const container = document.getElementById("cve-list");
-    container.classList.add("cve-group");
-    container.innerHTML = list;
-    document.getElementById("resultsCount").textContent =
-      `${filteredData.length} matches | CVEs: ${uniqueCves.size} | Artifacts: ${uniqueArtifacts.size}`;
-    const pagination = document.getElementById("pagination");
-    pagination.innerHTML = "";
-    pagination.style.display = "none";
-    return;
-  } else {
-    document.getElementById("cve-list").classList.remove("cve-group");
-  }
-
-  const totalPages = Math.ceil(filteredData.length / resultsPerPage);
-  if (currentPage > totalPages && totalPages > 0) {
-    currentPage = 1;
-  }
-
-  const start = (currentPage - 1) * resultsPerPage;
-  const end = start + resultsPerPage;
-  const currentItems = filteredData.slice(start, end);
-
-  const list = currentItems.map(item => {
-    const epss = item.vulnerability.epss?.[0]?.epss ?? "n/a";
-    const artifactName = item.artifact?.id ?? "Unknown";
-    const percentile = item.vulnerability.epss?.[0]?.percentile ?? "n/a";
-  const percentileFormatted = typeof percentile === 'number' ? (percentile * 100).toFixed(2) + '%' : "n/a";
-  const risk = item.vulnerability.risk ?? "n/a";
-  const riskFormatted = typeof risk === 'number' ? risk.toFixed(2) : "n/a";
-    const fixState = item.vulnerability.fix?.state ?? "unknown";
-    return `
-      <div class="cve-entry">
-        <strong><a style="color: #005f73" href="https://nvd.nist.gov/vuln/detail/${item.vulnerability.id}" target="_blank">
-          ${item.vulnerability.id}
-        </a></strong>
-        <div>Artifact: ${artifactName}</div>
-        <div>Severity: ${item.vulnerability.severity}</div>
-        <div>Namespace: ${item.vulnerability.namespace}</div>
-        <div>EPSS: ${epss}</div>
-        <div>Percentile: ${percentileFormatted}</div>
-        <div>Risk Score: ${riskFormatted}</div>
-         <div>Fix Status: <strong>${fixState}</strong></div>
-      </div>
-    `;
+    const count = items.length > 1 ? ` (${items.length})` : "";
+    return `<details open><summary><a style=\"color: #005f73\" href=\"https://nvd.nist.gov/vuln/detail/${cveId}\" target=\"_blank\">${cveId}</a>${count}</summary>${entries}</details>`;
   }).join("");
 
-  document.getElementById("cve-list").innerHTML = list;
-
+  const container = document.getElementById("cve-list");
+  container.classList.add("cve-group");
+  container.innerHTML = list;
   document.getElementById("resultsCount").textContent =
-  `Showing ${start + 1}-${Math.min(end, filteredData.length)} of ${filteredData.length} results | CVEs: ${uniqueCves.size} | Artifacts: ${uniqueArtifacts.size}`;
-
-  const pagination = document.getElementById("pagination");
-  pagination.style.display = "";
-  pagination.innerHTML = `
-    Page ${currentPage} of ${totalPages}
-    <button onclick="changePage(-1)" ${currentPage === 1 ? "disabled" : ""}>⬅</button>
-    <button onclick="changePage(1)" ${currentPage === totalPages ? "disabled" : ""}>➡</button>
-  `;
-}
-
-function changePage(delta) {
-  currentPage += delta;
-  render();
+    `${filteredData.length} matches | CVEs: ${uniqueCves.size} | Artifacts: ${uniqueArtifacts.size}`;
 }

--- a/script.js
+++ b/script.js
@@ -44,6 +44,10 @@ document.getElementById("collapseAll").addEventListener("click", () => {
   document.querySelectorAll("#cve-list details").forEach(d => d.open = false);
 });
 
+document.getElementById("expandAll").addEventListener("click", () => {
+  document.querySelectorAll("#cve-list details").forEach(d => d.open = true);
+});
+
 
 
 function applyFilters() {

--- a/style.css
+++ b/style.css
@@ -86,25 +86,6 @@ h1 {
   border-radius: 5px;
 }
 
-#pagination {
-  display: inline-block;
-  margin: 0 10px;
-}
-
-#pagination button {
-  padding: 6px 12px;
-  margin-left: 5px;
-  border: none;
-  background-color: #005f73;
-  color: white;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-#pagination button[disabled] {
-  background-color: #aaa;
-  cursor: not-allowed;
-}
 
 /* Dropdown menu */
 .dropdown {

--- a/style.css
+++ b/style.css
@@ -157,3 +157,12 @@ h1 {
 .form-group-vertical input {
   max-width: 180px;
 }
+
+.filter-button {
+  background-color: #005f73;
+  color: white;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}

--- a/style.css
+++ b/style.css
@@ -64,6 +64,19 @@ h1 {
   padding: 20px;
 }
 
+.cve-group details {
+  margin: 10px 0;
+  padding: 5px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+}
+
+.cve-group summary {
+  padding: 5px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
 .cve-entry {
   background-color: white;
   border: 1px solid #ddd;

--- a/style.css
+++ b/style.css
@@ -41,6 +41,12 @@ h1 {
   flex-wrap: wrap;
 }
 
+.right-controls {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+}
+
 #filters label {
   font-weight: 500;
 }

--- a/style.css
+++ b/style.css
@@ -86,6 +86,26 @@ h1 {
   border-radius: 5px;
 }
 
+#pagination {
+  display: inline-block;
+  margin: 0 10px;
+}
+
+#pagination button {
+  padding: 6px 12px;
+  margin-left: 5px;
+  border: none;
+  background-color: #005f73;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#pagination button[disabled] {
+  background-color: #aaa;
+  cursor: not-allowed;
+}
+
 
 /* Dropdown menu */
 .dropdown {


### PR DESCRIPTION
## Summary
- add UI toggle to group results by CVE
- compute unique CVE and artifact counts and display
- support details/summary grouping with basic styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b58eb1ce2483289ea8863636d751cb