### PR TITLE
Use DataTables to display CVE results with grouping

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,79 +5,47 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vulnerability Viewer</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/rowgroup/1.4.1/css/rowGroup.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.dataTables.min.css">
 </head>
 <body>
-  <h1> Aesys Vulnerability Viewer</h1>
+  <h1>Aesys Vulnerability Viewer</h1>
 
-<div id="filters">
-  <div class="filter-row">
+  <div id="controls">
     <input type="file" id="fileInput" accept=".json">
+    <label for="groupBy">Raggruppa per:</label>
+    <select id="groupBy">
+      <option value="">Nessuno</option>
+      <option value="id">CVE ID</option>
+      <option value="artifact">Artifact</option>
+    </select>
 
-    <div class="dropdown">
-      <button class="dropdown-toggle" type="button">Severity ▼</button>
-      <div class="dropdown-menu">
-        <label><input type="checkbox" name="severity" value="Critical"> Critical</label>
-        <label><input type="checkbox" name="severity" value="High"> High</label>
-        <label><input type="checkbox" name="severity" value="Medium"> Medium</label>
-        <label><input type="checkbox" name="severity" value="Low"> Low</label>
-      </div>
-    </div>
-
-    <div class="dropdown">
-  <button class="dropdown-toggle" type="button">Fix Status ▼</button>
-  <div class="dropdown-menu">
-    <label><input type="checkbox" name="fixstate" value="fixed"> Fixed</label>
-    <label><input type="checkbox" name="fixstate" value="not-fixed"> Not Fixed</label>
-    <label><input type="checkbox" name="fixstate" value="unknown"> Unknown</label>
-  </div>
-</div>
-
-
-   <div class="form-group-vertical">
-  <label for="riskThreshold">EPSS ></label>
-  <input type="number" id="riskThreshold" step="0.01" min="0" max="1" placeholder="e.g. 0.7">
-</div>
-
-<div class="form-group-vertical">
-  <label for="percentileThreshold">Percentile ></label>
-  <input type="number" id="percentileThreshold" step="0.0001" min="0" max="1" placeholder="e.g. 0.95">
-</div>
-
-<div class="form-group-vertical">
-  <label for="riskScore">Risk ></label>
-  <input type="number" id="riskScore" step="0.01" min="0" max="100" placeholder="e.g. 70">
-</div>
-
-
-<div class="form-group-vertical">
-  <label for="searchId">Search CVE ID</label>
-  <input type="text" id="searchId" placeholder="e.g. CVE-2024-1234">
-</div>
-
+    <button id="collapseAll" disabled>Riduci tutti</button>
+    <button id="expandAll" disabled>Espandi tutti</button>
   </div>
 
-  <div class="filter-row bottom-row">
-    <div id="resultsCount" style="font-weight: bold;"></div>
-    <div class="right-controls">
-      <button id="expandAll" class="filter-button">Expand all</button>
-      <button id="collapseAll" class="filter-button">Collapse all</button>
-      <div class="form-group">
-        <label for="perPage">Results per page</label>
-        <select id="perPage">
-          <option value="10">10</option>
-          <option value="25">25</option>
-          <option value="50" selected>50</option>
-          <option value="100">100</option>
-        </select>
-      </div>
-      <div id="pagination"></div>
-    </div>
-  </div>
-</div>
+  <table id="cveTable" class="display">
+    <thead>
+      <tr>
+        <th>CVE ID</th>
+        <th>Severity</th>
+        <th>Namespace</th>
+        <th>EPSS</th>
+        <th>Percentile</th>
+        <th>Risk Score</th>
+        <th>Fix Status</th>
+        <th>Artifact</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
 
-
-<div id="cve-list"></div>
-
-<script src="script.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/rowgroup/1.4.1/js/dataTables.rowGroup.min.js"></script>
+  <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 <body>
   <h1>Aesys Vulnerability Viewer</h1>
 
+  <!-- Control panel: file input, grouping selector and buttons -->
   <div id="controls">
     <input type="file" id="fileInput" accept=".json">
     <label for="groupBy">Raggruppa per:</label>
@@ -25,6 +26,7 @@
     <button id="expandAll" disabled>Espandi tutti</button>
   </div>
 
+  <!-- DataTables placeholder where rows will be injected -->
   <table id="cveTable" class="display">
     <thead>
       <tr>
@@ -41,6 +43,7 @@
     <tbody></tbody>
   </table>
 
+  <!-- Libraries: jQuery and DataTables -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/rowgroup/1.4.1/js/dataTables.rowGroup.min.js"></script>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,3 @@
-
 body {
   font-family: 'Segoe UI', sans-serif;
   margin: 0;
@@ -15,160 +14,36 @@ h1 {
   font-size: 1.5rem;
 }
 
-#filters {
+#controls {
   position: sticky;
   top: 0;
-  background-color: white;
-  padding: 10px 20px;
-  z-index: 100;
-  border-bottom: 1px solid #ccc;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
-  font-size: 0.95rem;
-}
-
-.filter-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 15px;
-  margin-bottom: 10px;
-}
-
-.bottom-row {
-  justify-content: space-between;
+  background-color: #f9f9f9;
+  z-index: 1000;
+  padding: 10px 0;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
 }
 
-.right-controls {
-  display: flex;
-  align-items: center;
-  gap: 15px;
+#controls > * {
+  margin: 10px 20px;
 }
 
-#filters label {
-  font-weight: 500;
-}
-
-#filters input[type="file"],
-#filters select,
-#filters input[type="number"],
-#filters input[type="text"] {
-  padding: 5px 8px;
-  margin-right: 10px;
-  margin-top: 5px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-}
-
-#filters input[type="checkbox"] {
-  margin-right: 5px;
-}
-
-#cve-list {
-  padding: 20px;
-}
-
-.cve-group details {
-  margin: 10px 0;
-  padding: 5px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-}
-
-.cve-group summary {
-  padding: 5px;
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.cve-entry {
-  background-color: white;
-  border: 1px solid #ddd;
-  border-left: 5px solid #005f73;
-  margin: 10px 0;
-  padding: 15px;
-  border-radius: 5px;
-}
-
-#pagination {
-  display: inline-block;
-  margin: 0 10px;
-}
-
-#pagination button {
-  padding: 6px 12px;
-  margin-left: 5px;
-  border: none;
-  background-color: #005f73;
-  color: white;
-  border-radius: 4px;
+tr.dtrg-start {
   cursor: pointer;
 }
 
-#pagination button[disabled] {
-  background-color: #aaa;
-  cursor: not-allowed;
+tr.dtrg-start td {
+  background-color: #cbd5e1;
+  font-weight: bold;
 }
 
-
-/* Dropdown menu */
-.dropdown {
-  position: relative;
-  display: inline-block;
+tr.dtrg-start.collapsed td {
+  opacity: 0.7;
 }
 
-.dropdown-toggle {
-  background-color: #005f73;
-  color: white;
-  padding: 6px 12px;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 0.9rem;
+#cveTable {
+  width: 100%;
+  margin: 20px auto;
 }
 
-.dropdown-menu {
-  display: none;
-  position: absolute;
-  background-color: white;
-  min-width: 140px;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);
-  padding: 8px;
-  z-index: 200;
-  top: 100%;
-  left: 0;
-}
-
-.dropdown-menu label {
-  display: block;
-  font-size: 0.9rem;
-  margin-bottom: 4px;
-}
-
-.dropdown:hover .dropdown-menu {
-  display: block;
-}
-
-.form-group-vertical {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin-right: 15px;
-}
-
-.form-group-vertical input {
-  max-width: 180px;
-}
-
-.filter-button {
-  background-color: #005f73;
-  color: white;
-  padding: 6px 12px;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-}

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+/* Base layout -------------------------------------------------------- */
 body {
   font-family: 'Segoe UI', sans-serif;
   margin: 0;
@@ -14,6 +15,7 @@ h1 {
   font-size: 1.5rem;
 }
 
+/* Sticky bar with file input and controls --------------------------- */
 #controls {
   position: sticky;
   top: 0;
@@ -29,6 +31,7 @@ h1 {
   margin: 10px 20px;
 }
 
+/* Row group headers -------------------------------------------------- */
 tr.dtrg-start {
   cursor: pointer;
 }
@@ -42,6 +45,7 @@ tr.dtrg-start.collapsed td {
   opacity: 0.7;
 }
 
+/* DataTable ---------------------------------------------------------- */
 #cveTable {
   width: 100%;
   margin: 20px auto;


### PR DESCRIPTION
## Summary
- Use distinct, arrow-labeled group headers and add controls to collapse or expand all groups
- Replace manual severity and fix status selects with DataTables header dropdown filters
- Keep filter controls and table header fixed to the top during scrolling
- Fix DataTables initialization by adjusting FixedHeader via API to avoid early `table` access

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c1ae6fc48328b5d703d3b0130364