### PR TITLE
feat: add DataTable filter row

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vulnerability Viewer</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
 </head>
 <body>
   <h1> Aesys Vulnerability Viewer</h1>
@@ -75,9 +76,34 @@
   </div>
 </div>
 
+<table id="cveTable" class="display">
+  <thead>
+    <tr>
+      <th>CVE</th>
+      <th>Severity</th>
+      <th>EPSS</th>
+      <th>Percentile</th>
+      <th>Risk Score</th>
+      <th>Artifact</th>
+      <th>Fix Status</th>
+    </tr>
+    <tr>
+      <th>CVE</th>
+      <th></th>
+      <th>EPSS</th>
+      <th>Percentile</th>
+      <th>Risk Score</th>
+      <th>Artifact</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>
 
 <div id="cve-list"></div>
 
+<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
 <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -151,3 +151,44 @@ function changePage(delta) {
   currentPage += delta;
   render();
 }
+
+$(document).ready(function () {
+  const table = $('#cveTable').DataTable({
+    orderCellsTop: true,
+    initComplete: function () {
+      const api = this.api();
+      [1, 6].forEach(function (colIdx) {
+        const column = api.column(colIdx);
+        const cell = $('#cveTable thead tr:eq(1) th').eq(colIdx);
+        const select = $('<select class="dt-select"><option value=""></option></select>')
+          .appendTo(cell)
+          .on('change', function () {
+            const val = $.fn.dataTable.util.escapeRegex($(this).val());
+            column.search(val ? '^' + val + '$' : '', true, false).draw();
+          });
+
+        column.data().unique().sort().each(function (d) {
+          if (d) {
+            select.append('<option value="' + d + '">' + d + '</option>');
+          }
+        });
+      });
+    }
+  });
+
+  window.updateFilters = function () {
+    [1, 6].forEach(function (colIdx) {
+      const column = table.column(colIdx);
+      const cell = $('#cveTable thead tr:eq(1) th').eq(colIdx);
+      const select = cell.find('select');
+      const current = select.val();
+      select.empty().append('<option value=""></option>');
+      column.data().unique().sort().each(function (d) {
+        if (d) {
+          select.append('<option value="' + d + '">' + d + '</option>');
+        }
+      });
+      if (current) select.val(current);
+    });
+  };
+});


### PR DESCRIPTION
## Summary
- add filter row to CVE table header for DataTables
- populate severity and fix status selects with unique column values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b890cab08328b473c8d6319979eb