### PR TITLE
Enable SearchBuilder with numeric filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/select/1.7.0/css/select.dataTables.min.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/searchpanes/2.2.0/css/searchPanes.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/searchbuilder/1.5.0/css/searchBuilder.dataTables.min.css">
 </head>
 <body>
   <h1>Aesys Vulnerability Viewer</h1>
@@ -52,6 +53,7 @@
   <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
   <script src="https://cdn.datatables.net/select/1.7.0/js/dataTables.select.min.js"></script>
   <script src="https://cdn.datatables.net/searchpanes/2.2.0/js/dataTables.searchPanes.min.js"></script>
+  <script src="https://cdn.datatables.net/searchbuilder/1.5.0/js/dataTables.searchBuilder.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -53,12 +53,18 @@ $(document).ready(function () {
           .toggleClass("collapsed", collapsed);
       }
     },
-    pageLength: 50,
-    dom: 'Plfrtip',
-    searchPanes: {
-      columns: [1, 6]
-    }
-  });
+      pageLength: 50,
+      columnDefs: [
+        { targets: [3, 4, 5], type: 'num' }
+      ],
+      dom: 'QPlfrtip',
+      searchBuilder: {
+        columns: [3, 4, 5]
+      },
+      searchPanes: {
+        columns: [1, 6]
+      }
+    });
 
   table.rowGroup().disable();
 


### PR DESCRIPTION
## Summary
- load SearchBuilder CSS and JS from CDN
- allow SearchBuilder on numeric EPSS, Percentile, and Risk Score columns
- ensure numeric comparisons by setting column types

## Testing
- ⚠️ `node <<'NODE'` (SearchBuilder failed to initialise in jsdom environment)


------
https://chatgpt.com/codex/tasks/task_e_68b6da6d983c83289bc23e9800661e81