### PR TITLE
feat: upgrade DataTables to v2

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vulnerability Viewer</title>
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/rowgroup/1.4.1/css/rowGroup.dataTables.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/3.4.0/css/fixedHeader.dataTables.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/select/1.7.0/css/select.dataTables.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/searchpanes/2.2.0/css/searchPanes.dataTables.min.css">
-  <link rel="stylesheet" href="https://cdn.datatables.net/searchbuilder/1.5.0/css/searchBuilder.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/rowgroup/1.5.0/css/rowGroup.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/fixedheader/4.0.0/css/fixedHeader.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/select/2.0.3/css/select.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/searchpanes/2.3.1/css/searchPanes.dataTables.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/searchbuilder/1.7.0/css/searchBuilder.dataTables.min.css">
 </head>
 <body>
   <h1>Aesys Vulnerability Viewer</h1>
@@ -48,12 +48,12 @@
 
   <!-- Libraries: jQuery and DataTables -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-  <script src="https://cdn.datatables.net/rowgroup/1.4.1/js/dataTables.rowGroup.min.js"></script>
-  <script src="https://cdn.datatables.net/fixedheader/3.4.0/js/dataTables.fixedHeader.min.js"></script>
-  <script src="https://cdn.datatables.net/select/1.7.0/js/dataTables.select.min.js"></script>
-  <script src="https://cdn.datatables.net/searchpanes/2.2.0/js/dataTables.searchPanes.min.js"></script>
-  <script src="https://cdn.datatables.net/searchbuilder/1.5.0/js/dataTables.searchBuilder.min.js"></script>
+  <script src="https://cdn.datatables.net/2.0.8/js/dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/rowgroup/1.5.0/js/dataTables.rowGroup.min.js"></script>
+  <script src="https://cdn.datatables.net/fixedheader/4.0.0/js/dataTables.fixedHeader.min.js"></script>
+  <script src="https://cdn.datatables.net/select/2.0.3/js/dataTables.select.min.js"></script>
+  <script src="https://cdn.datatables.net/searchpanes/2.3.1/js/dataTables.searchPanes.min.js"></script>
+  <script src="https://cdn.datatables.net/searchbuilder/1.7.0/js/dataTables.searchBuilder.min.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
   let storedOrder = [];                  // previous sorting before grouping
 
   // --- DataTables initialisation ---
-  const table = $("#cveTable").DataTable({
+  const table = new DataTable('#cveTable', {
     fixedHeader: {
       header: true,
       headerOffset: HEADER_OFFSET
@@ -28,6 +28,10 @@ $(document).ready(function () {
       { title: "Risk Score", data: "risk" },
       { title: "Fix Status", data: "fix" },
       { title: "Artifact", data: "artifact" }
+    ],
+    columnControl: [
+      { target: 0, content: ['order'] },
+      { target: 1, content: ['search'] }
     ],
     rowGroup: {
       dataSrc: "artifact",
@@ -57,7 +61,12 @@ $(document).ready(function () {
       columnDefs: [
         { targets: [3, 4, 5], type: 'num' }
       ],
-      dom: 'QPlfrtip',
+      layout: {
+        topStart: ['searchBuilder', 'searchPanes'],
+        topEnd: ['pageLength', 'search'],
+        bottomStart: ['info'],
+        bottomEnd: ['paging']
+      },
       searchBuilder: {
         columns: [3, 4, 5]
       },

--- a/style.css
+++ b/style.css
@@ -51,3 +51,9 @@ tr.dtrg-start.collapsed td {
   margin: 20px auto;
 }
 
+/* Ensure column search inputs fill the header cell */
+#cveTable thead input {
+  width: 100%;
+  box-sizing: border-box;
+}
+


### PR DESCRIPTION
## Summary
- upgrade DataTables core and extensions to 2.x CDN links
- initialize table with new `DataTable` API and column controls
- style column search inputs to span header cells

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6f80683d8832895d41b931a16490f