### PR TITLE
chore: improve theme and interactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,15 +1,25 @@
+/* Color palette ------------------------------------------------------ */
+:root {
+  --primary: #005f73;
+  --accent: #94d2bd;
+  --background: #f9f9f9;
+  --text: #333333;
+  --on-primary: #ffffff;
+  --group-header: #cbd5e1;
+}
+
 /* Base layout -------------------------------------------------------- */
 body {
   font-family: 'Segoe UI', sans-serif;
   margin: 0;
-  background-color: #f9f9f9;
-  color: #333;
+  background-color: var(--background);
+  color: var(--text);
 }
 
 h1 {
   text-align: center;
-  background-color: #005f73;
-  color: white;
+  background-color: var(--primary);
+  color: var(--on-primary);
   padding: 10px 0;
   margin: 0;
   font-size: 1.5rem;
@@ -19,7 +29,7 @@ h1 {
 #controls {
   position: sticky;
   top: 0;
-  background-color: #f9f9f9;
+  background-color: var(--background);
   z-index: 1000;
   padding: 10px 0;
   display: flex;
@@ -37,7 +47,7 @@ tr.dtrg-start {
 }
 
 tr.dtrg-start td {
-  background-color: #cbd5e1;
+  background-color: var(--group-header);
   font-weight: bold;
 }
 
@@ -55,5 +65,40 @@ tr.dtrg-start.collapsed td {
 #cveTable thead input {
   width: 100%;
   box-sizing: border-box;
+}
+
+/* Buttons ------------------------------------------------------------- */
+button {
+  background-color: var(--primary);
+  color: var(--on-primary);
+  border: none;
+  border-radius: 4px;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+button:hover,
+button:focus {
+  background-color: var(--accent);
+  color: var(--text);
+}
+
+button:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Row interactions ---------------------------------------------------- */
+#cveTable tbody tr {
+  transition: background-color 0.2s ease-in-out;
+}
+
+#cveTable tbody tr:hover,
+#cveTable tbody tr:focus {
+  background-color: var(--accent);
+}
+
+#cveTable tbody tr:focus {
+  outline: 2px solid var(--primary);
 }
 


### PR DESCRIPTION
## Summary
- define CSS variables for shared color palette
- add hover and focus states for buttons and table rows

## Testing
- `python - <<'PY'
from wcag_contrast_ratio import rgb, passes_AA

def hex_to_rgb(hex_color):
    hex_color = hex_color.lstrip('#')
    return tuple(int(hex_color[i:i+2], 16)/255 for i in (0, 2, 4))

primary = '#005f73'
on_primary = '#ffffff'
accent = '#94d2bd'
text = '#333333'

primary_ratio = rgb(hex_to_rgb(primary), hex_to_rgb(on_primary))
accent_ratio = rgb(hex_to_rgb(accent), hex_to_rgb(text))

print('primary/on-primary ratio:', primary_ratio, 'AA:', passes_AA(primary_ratio))
print('accent/text ratio:', accent_ratio, 'AA:', passes_AA(accent_ratio))
PY`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b84989ef188328ab789be4d4e79a91