### PR TITLE
Enable responsive DataTable layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,8 @@
   <link rel="stylesheet" href="https://cdn.datatables.net/colreorder/2.1.1/css/colReorder.dataTables.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/buttons/3.2.4/css/buttons.dataTables.css">
   <link rel="stylesheet" href="https://cdn.datatables.net/searchpanes/2.3.5/css/searchPanes.dataTables.css">
-<link rel="stylesheet" href="https://cdn.datatables.net/select/3.0.1/css/select.dataTables.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/select/3.0.1/css/select.dataTables.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/responsive/3.0.0/css/responsive.dataTables.min.css">
 </head>
 <body>
   <h1>Aesys Vulnerability Viewer</h1>
@@ -69,6 +70,7 @@
   <script src="https://cdn.datatables.net/select/3.0.1/js/dataTables.select.js"></script>
   <script src="https://cdn.datatables.net/select/3.0.1/js/select.dataTables.js"></script>
   <script src="https://cdn.datatables.net/select/3.0.1/js/select.dataTables.js"></script>
+  <script src="https://cdn.datatables.net/responsive/3.0.0/js/dataTables.responsive.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js"></script>

--- a/script.js
+++ b/script.js
@@ -69,6 +69,7 @@ $(document).ready(function () {
       columnDefs: [
         { targets: [3, 4, 5], type: 'num' }
       ],
+      responsive: true,
       layout: {
         top1: {
             buttons: ['copy', 'csv', 'excel', 'pdf', 'print']

--- a/style.css
+++ b/style.css
@@ -49,6 +49,9 @@ tr.dtrg-start.collapsed td {
 #cveTable {
   width: 100%;
   margin: 20px auto;
+  /* Allow horizontal scrolling on small viewports */
+  overflow-x: auto;
+  display: block;
 }
 
 /* Ensure column search inputs fill the header cell */


### PR DESCRIPTION
## Summary
- add DataTables responsive extension and enable responsive mode
- allow table to scroll on small screens

## Testing
- `node - <<'NODE'
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({args:['--no-sandbox']});
  const page = await browser.newPage();
  await page.setViewport({width:600, height:800});
  await page.goto('file://' + process.cwd() + '/index.html');
  await page.waitForSelector('#cveTable');
  await page.waitForTimeout(1000);
  const isResponsive = await page.evaluate(() => document.querySelector('#cveTable').classList.contains('dtr-inline') || document.querySelector('#cveTable').classList.contains('dtr-column'));
  console.log('Responsive enabled:', isResponsive);
  await browser.close();
})();
NODE` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b69ecd8832880f02b6e3fd2bee3